### PR TITLE
Replace the timestep_limit call with the new tags api.

### DIFF
--- a/gym_ple/__init__.py
+++ b/gym_ple/__init__.py
@@ -8,6 +8,6 @@ for game in ['Catcher', 'MonsterKong', 'FlappyBird', 'PixelCopter', 'PuckWorld',
         id='{}-v0'.format(game),
         entry_point='gym_ple:PLEEnv',
         kwargs={'game_name': game, 'display_screen':False},
-        timestep_limit=10000,
+        tags={'wrapper_config.TimeLimit.max_episode_steps': 10000},
         nondeterministic=nondeterministic,
     )

--- a/gym_ple/example.py
+++ b/gym_ple/example.py
@@ -2,6 +2,7 @@ import logging
 import os, sys
 
 import gym
+from gym.wrappers import Monitor
 import gym_ple
 
 # The world's simplest agent!
@@ -26,7 +27,7 @@ if __name__ == '__main__':
     # will be namespaced). You can also dump to a tempdir if you'd
     # like: tempfile.mkdtemp().
     outdir = '/tmp/random-agent-results'
-    env.monitor.start(outdir, force=True, seed=0)
+    env = Monitor(env, directory=outdir, force=True)
 
     # This declaration must go *after* the monitor call, since the
     # monitor's seeding creates a new action_space instance with the
@@ -51,7 +52,7 @@ if __name__ == '__main__':
             # Video is not recorded every episode, see capped_cubic_video_schedule for details.
 
     # Dump result info to disk
-    env.monitor.close()
+    env.close()
 
     # Upload to the scoreboard. We could also do this from another
     # process if we wanted.


### PR DESCRIPTION
Fixes deprecation warnings. openai/gym@28906117 deprecated the `timestep_limit` call and replaced it with the `tags` api. 