### PR TITLE
set headless mode to avoid double screen

### DIFF
--- a/gym_ple/ple_env.py
+++ b/gym_ple/ple_env.py
@@ -1,3 +1,4 @@
+import os
 import gym
 from gym import spaces
 from ple import PLE
@@ -7,6 +8,9 @@ class PLEEnv(gym.Env):
     metadata = {'render.modes': ['human', 'rgb_array']}
 
     def __init__(self, game_name='FlappyBird', display_screen=True):
+        # set headless mode
+        os.environ['SDL_VIDEODRIVER'] = 'dummy'
+        
         # open up a game state to communicate with emulator
         import importlib
         game_module_name = ('ple.games.%s' % game_name).lower()


### PR DESCRIPTION
According to the following issue, we can set headless mode to avoid the [duplicate screen](https://github.com/lusob/gym-ple/issues/1).

[Run without creating pygame window?](https://github.com/ntasfi/PyGame-Learning-Environment/issues/26)
