### PR TITLE
Correct deprecated "tags" argument

### DIFF
--- a/gym_ple/__init__.py
+++ b/gym_ple/__init__.py
@@ -7,7 +7,7 @@ for game in ['Catcher', 'MonsterKong', 'FlappyBird', 'PixelCopter', 'PuckWorld',
     register(
         id='{}-v0'.format(game),
         entry_point='gym_ple:PLEEnv',
+        max_episode_steps=10000,
         kwargs={'game_name': game, 'display_screen':False},
-        tags={'wrapper_config.TimeLimit.max_episode_steps': 10000},
         nondeterministic=nondeterministic,
     )


### PR DESCRIPTION
OpenAI Gym _register_ function's max episode steps has been moved from "tags" argument to "max_episode_steps" argument since gym commit [f6a005bae747cd16ac97c787472a797672a444cf](https://github.com/openai/universe/commit/f6a005bae747cd16ac97c787472a797672a444cf).

This Pull Request updates gym-ple's implementation of _register_ for maintenance purposes.