### PR TITLE
add close method

### DIFF
--- a/gym_ple/ple_env.py
+++ b/gym_ple/ple_env.py
@@ -70,4 +70,7 @@ class PLEEnv(gym.Env):
         self.game_state.rng = rng
         self.game_state.game.rng = self.game_state.rng
 
-        self.game_state.init()
+    def close(self):
+        if self.viewer is not None:
+            self.viewer.close()
+            self.viewer = None


### PR DESCRIPTION
most environments use env.close() to close the renderer, this makes it work like the others

mentioned by the maintainers of the gym here: https://github.com/openai/gym/issues/1056